### PR TITLE
fix: Excluding erroneous terraform version

### DIFF
--- a/internal/checker/updates.go
+++ b/internal/checker/updates.go
@@ -218,12 +218,12 @@ func (c *Client) Versions(s source.Source) ([]*goversion.Version, error) {
 }
 
 func filterTerraformTags(s source.Source, versions []*goversion.Version) []*goversion.Version {
-	// This is dumb but hashicorp have left two random tags in their git repo for v11 and 26258 lol!!
+	// This is dumb but hashicorp have left three random tags in their git repo for v11, 26258 and 20240919 lol!!
 	// Here we simply remove these from the results.
 	vers := []*goversion.Version{}
 	if s.Git.Remote == "https://github.com/hashicorp/terraform.git" {
 		for _, v := range versions {
-			if v.String() != "11.0.0" && v.String() != "26258.0.0" {
+			if v.String() != "11.0.0" && v.String() != "26258.0.0" && v.String() != "20240919.0.0" {
 				vers = append(vers, v)
 			}
 		}


### PR DESCRIPTION
I've been trying this tool out, and it's giving a funny response for the latest available Terraform version:
```
terraform FAILED Outdated major version
────────────────────────────────────────────────────────────────────────────────

  Resolution
  ───────────────────────────────────────────────────────────────────
  Consider migrating to the latest major version of terraform

  Details
  ───────────────────────────────────────────────────
  Type:                terraform
  Path:                /src/terraform/terragrunt/provider-version-monitor
  Name:                terraform
  Source:              github.com/hashicorp/terraform
  Version Constraints: = 1.8.4
  Version:             
  Latest Match:        1.8.4
  Latest Overall:      20240919.0.0

────────────────────────────────────────────────────────────────────────────────
-------------
```

Did some digging and found that `20240919` is the name of a branch on the hashicorp/terraform repo. Looks to me that the `Git` function in the `versions` package is pulling down a list of all refs from the repo, which includes branch names as well as tags. It then attempts to create a version number from each of those, skipping those that aren't parsable as version numbers. Problem with that approach is that a branch name can be anything, so if it's anything resembling a version number, it will be parsed as a version number.

The `filterTerraformTags` function already filters out two branches which have been erroneously found as tags by this logic, so I'm adding this new branch to that list as a quick fix. I've built locally and run against the TF files in the example dir to check it's working, and it does. In the long run though, it would be better to rewrite the `Git` function to search for _only_ tags , and not include all refs when looking at a GitHub repo. Given that this project seems to be abandoned and my PR is therefore unlikely to be merged, I'm not going to spend my time on that right now, and instead write my own tool for this. I'll just leave this here in case anyone hits the same problem.